### PR TITLE
Fix DESCRIPTION dependency list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,30 +4,32 @@ Version: 0.1.0
 Authors@R: c(
     person("Nicolas", "Ferry", , "ferrynicolas@me.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5191-9648")),
-    person(family = "Bavarian Forest National Park Administration",
-         role = "cph"))
-Description: Converts camera trap data (site, timestamp, species) into a recurrent event format suited for recurrent event analyses.
- It requires to specify which species (primary, one or more) affect the other (secondary, only one) and the maximum duration of a survey (d).
- For each observation of the primary species, the function creates a survey during which all observations of the secondary species are recorded (i.e. the recurrent events), indicating the time of the previous event (t.start) and the time since the beginning of the survey (t.stop).
+    person(, "Bavarian Forest National Park Administration", role = "cph")
+  )
+Description: Converts camera trap data (site, timestamp, species) into a
+    recurrent event format suited for recurrent event analyses.  It
+    requires to specify which species (primary, one or more) affect the
+    other (secondary, only one) and the maximum duration of a survey (d).
+    For each observation of the primary species, the function creates a
+    survey during which all observations of the secondary species are
+    recorded (i.e. the recurrent events), indicating the time of the
+    previous event (t.start) and the time since the beginning of the
+    survey (t.stop).
 License: GPL (>= 3)
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
-Depends: R (>= 3.5.0)
-Imports:
-    dplyr,
-    lubridate,
-    magrittr,
-    checkmate
-Suggests:
-    testthat (>= 3.0.0)
-Config/Needs/website:
-  knitr,
-  pammtools,
-  reReg,
-  ggplot2
-  patchwork
-NeedsCompilation: no
 URL: https://adibender.github.io/ctrecurrent/
 BugReports: https://github.com/adibender/ctrecurrent/issues
+Depends: 
+    R (>= 3.5.0)
+Imports:
+    checkmate,
+    dplyr,
+    lubridate,
+    magrittr
+Suggests:
+    testthat (>= 3.0.0)
+Config/Needs/website: knitr, pammtools, reReg, ggplot2, patchwork
+Encoding: UTF-8
+LazyData: true
+NeedsCompilation: no
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.1


### PR DESCRIPTION
Adds a missing comma such that `pak` can parse the website dependencies for the GitHub Action.
Also applies `usethis::use_tidy_description()` to ensure a standardized order of DESCRIPTION elements.