### PR TITLE
Add time_unit argument to support hours/mins/weeks

### DIFF
--- a/R/ct-to-recurrent.R
+++ b/R/ct-to-recurrent.R
@@ -13,7 +13,8 @@
 #' @param secondary character(1) Name of the species affected by the primary (only one name allowed).
 #' @param tertiary character Names of the species in \code{species_var} that should not be considere primary or secondary.
 #' @param survey_end_date Date Date of study end (e.g. "01-01-2001")
-#' @param survey_duration integer(1) Maximum duration of the survey (in days, e.g. "7")
+#' @param survey_duration numeric(1) Maximum duration of the survey in the unit specified by \code{time_unit} (e.g. \code{7} for 7 days or \code{48} for 48 hours).
+#' @param time_unit character(1) Time unit for \code{survey_duration} and the resulting \code{t.start}/\code{t.stop} columns. One of \code{"days"} (default), \code{"hours"}, \code{"mins"}, \code{"secs"}, or \code{"weeks"}.
 #' @param species_var character(1) Name of the variable that contains species information.
 #' @param datetime_var Name of the variable that contains date time information.
 #' @param site_var Name of the variable that contains Site ID.
@@ -47,17 +48,19 @@ ct_to_recurrent = function(
   primary,
   secondary,
   survey_duration = 10,
+  time_unit       = "days",
   datetime_var    = "DateTime",
   species_var     = "Species",
   site_var        = "Site",
   tertiary        = NULL,
   survey_end_date = NULL) {
-  
+
   # Check inputs
   checkmate::assert_data_frame(data)
   checkmate::assert_character(primary, any.missing = FALSE, min.len = 1, unique = TRUE)
   checkmate::assert_string(secondary)
-  checkmate::assert_integerish(survey_duration, len = 1, any.missing = FALSE)
+  checkmate::assert_numeric(survey_duration, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assert_choice(time_unit, choices = c("secs", "mins", "hours", "days", "weeks"))
   checkmate::assert_string(datetime_var)
   checkmate::assert_class(data[[datetime_var]], "POSIXt")
   checkmate::assert_string(species_var)
@@ -135,8 +138,8 @@ ct_to_recurrent = function(
     group_by(across(all_of("survey_id"))) %>%
     filter(any(.data[["event"]]==1)) %>% # Keep only survey with at least one secondary event
     mutate(t.stop = ifelse(is.na(lag(.data[[datetime_var]])), 0, # Primary event: t.stop = 0
-                           ifelse(lag(.data[[datetime_var]]) == .data[[datetime_var]], difftime(.data[[datetime_var]]+1, lag(.data[[datetime_var]]), units  = "days"), # Ties forbidden -> add 1 sec
-                                  difftime(.data[[datetime_var]], lag(.data[[datetime_var]]), units  = "days"))) %>% cumsum(), # Secondary events: t.stop = cumulative time between previous events
+                           ifelse(lag(.data[[datetime_var]]) == .data[[datetime_var]], difftime(.data[[datetime_var]]+1, lag(.data[[datetime_var]]), units = time_unit), # Ties forbidden -> add 1 sec
+                                  difftime(.data[[datetime_var]], lag(.data[[datetime_var]]), units = time_unit))) %>% cumsum(), # Secondary events: t.stop = cumulative time between previous events
            t.start = lag(.data[["t.stop"]])) %>%
     filter(!(.data[[species_var]] %in% primary)) %>% # Remove primary events
     mutate(enum = row_number()) # Secondary event number

--- a/R/ct-to-recurrent.R
+++ b/R/ct-to-recurrent.R
@@ -48,12 +48,12 @@ ct_to_recurrent = function(
   primary,
   secondary,
   survey_duration = 10,
-  time_unit       = "days",
   datetime_var    = "DateTime",
   species_var     = "Species",
   site_var        = "Site",
   tertiary        = NULL,
-  survey_end_date = NULL) {
+  survey_end_date = NULL,
+  time_unit       = "days") {
 
   # Check inputs
   checkmate::assert_data_frame(data)

--- a/man/ct_to_recurrent.Rd
+++ b/man/ct_to_recurrent.Rd
@@ -9,6 +9,7 @@ ct_to_recurrent(
   primary,
   secondary,
   survey_duration = 10,
+  time_unit = "days",
   datetime_var = "DateTime",
   species_var = "Species",
   site_var = "Site",
@@ -23,7 +24,9 @@ ct_to_recurrent(
 
 \item{secondary}{character(1) Name of the species affected by the primary (only one name allowed).}
 
-\item{survey_duration}{integer(1) Maximum duration of the survey (in days, e.g. "7")}
+\item{survey_duration}{numeric(1) Maximum duration of the survey in the unit specified by \code{time_unit} (e.g. \code{7} for 7 days or \code{48} for 48 hours).}
+
+\item{time_unit}{character(1) Time unit for \code{survey_duration} and the resulting \code{t.start}/\code{t.stop} columns. One of \code{"days"} (default), \code{"hours"}, \code{"mins"}, \code{"secs"}, or \code{"weeks"}.}
 
 \item{datetime_var}{Name of the variable that contains date time information.}
 

--- a/tests/testthat/test-trafo.R
+++ b/tests/testthat/test-trafo.R
@@ -1,26 +1,21 @@
 context("Test that trafo to recurrent works")
 
-test_that("Trafo works with correct inputs", {
+primary   <- "Deer"
+secondary <- "Coyote"
+tertiary  <- c("Fawn", "Bear", "Bobcat", "Human", "Motorized")
+end_date  <- max(murphy$DateTime)
 
-  primary = c("Deer")
-  # Define the secondary species (affected by the primary species, only one)
-  secondary = c("Coyote")
-  # Define the tertiary species (affecting the secondary species, censoring the survey if observed but not being the focus of the model)
-  tertiary = c("Fawn", "Bear", "Bobcat", "Human", "Motorized")
+test_that("Trafo works with correct inputs (default: days)", {
 
-  # Define the end of study
-  end_date = max(murphy$DateTime)
-
-  # Convert into recurrent event
   recu = ct_to_recurrent(
     murphy,
     primary,
     secondary,
-    tertiary = tertiary,
+    tertiary        = tertiary,
     survey_end_date = end_date,
     survey_duration = 30)
 
-  expect_equal(dim(recu),  c(221, 11))
+  expect_equal(dim(recu), c(221, 11))
   expect_set_equal(
     colnames(recu),
     c("Site", "survey_id", "datetime_primary", "primary", "secondary", "DateTime",
@@ -28,9 +23,72 @@ test_that("Trafo works with correct inputs", {
   )
   expect_equal(
     as.data.frame(recu[1:2, c("t.start", "t.stop", "event", "enum")]),
-    data.frame(t.start = c(0, 10.78403), t.stop = c(10.78403, 30), event = c(1, 0), enum = c(1L,2L)),
+    data.frame(t.start = c(0, 10.78403), t.stop = c(10.78403, 30), event = c(1, 0), enum = c(1L, 2L)),
     tolerance = 1e-5
   )
 
+})
 
+test_that("time_unit = 'hours' gives t.start/t.stop scaled by 24 vs days", {
+
+  recu_days = ct_to_recurrent(
+    murphy, primary, secondary,
+    tertiary        = tertiary,
+    survey_end_date = end_date,
+    survey_duration = 30,
+    time_unit       = "days")
+
+  recu_hours = ct_to_recurrent(
+    murphy, primary, secondary,
+    tertiary        = tertiary,
+    survey_end_date = end_date,
+    survey_duration = 30 * 24,
+    time_unit       = "hours")
+
+  # Same surveys and events selected
+  expect_equal(nrow(recu_days), nrow(recu_hours))
+  expect_equal(recu_days$event, recu_hours$event)
+  expect_equal(recu_days$survey_id, recu_hours$survey_id)
+
+  # t.start / t.stop should differ by factor 24
+  expect_equal(recu_hours$t.start, recu_days$t.start * 24, tolerance = 1e-5)
+  expect_equal(recu_hours$t.stop,  recu_days$t.stop  * 24, tolerance = 1e-5)
+
+})
+
+test_that("time_unit = 'mins' gives t.start/t.stop scaled by 1440 vs days", {
+
+  recu_days = ct_to_recurrent(
+    murphy, primary, secondary,
+    tertiary        = tertiary,
+    survey_end_date = end_date,
+    survey_duration = 30,
+    time_unit       = "days")
+
+  recu_mins = ct_to_recurrent(
+    murphy, primary, secondary,
+    tertiary        = tertiary,
+    survey_end_date = end_date,
+    survey_duration = 30 * 24 * 60,
+    time_unit       = "mins")
+
+  expect_equal(nrow(recu_days), nrow(recu_mins))
+  expect_equal(recu_days$event, recu_mins$event)
+  expect_equal(recu_mins$t.start, recu_days$t.start * 1440, tolerance = 1e-5)
+  expect_equal(recu_mins$t.stop,  recu_days$t.stop  * 1440, tolerance = 1e-5)
+
+})
+
+test_that("invalid time_unit throws an error", {
+  expect_error(
+    ct_to_recurrent(murphy, primary, secondary, time_unit = "years"),
+    regexp = "time_unit"
+  )
+})
+
+test_that("non-numeric survey_duration throws an error", {
+  expect_error(
+    ct_to_recurrent(murphy, primary, secondary, survey_duration = "30"),
+    regexp = "survey_duration"
+  )
 })


### PR DESCRIPTION
Closes #8

## Summary
- Adds a `time_unit` argument to `ct_to_recurrent()` (default: `"days"`, accepts `"secs"`, `"mins"`, `"hours"`, `"days"`, `"weeks"`)
- Passes `time_unit` to both `difftime()` calls so `t.start`/`t.stop` are computed in the chosen unit
- `survey_duration` is now interpreted in the same unit, allowing e.g. `survey_duration = 48, time_unit = "hours"` for sub-day analyses
- Updated assertion from `assert_integerish` to `assert_numeric` (hours-scale durations may be non-integer) with an added `assert_choice` for `time_unit`
- Updated documentation accordingly

## Test plan
- [x] Run existing tests to confirm default (`time_unit = "days"`) behaviour is unchanged
- [x] Test with `time_unit = "hours"` on a dataset with sub-day activity patterns